### PR TITLE
xorBlock does not run on 386 arch

### DIFF
--- a/cmac/hash.go
+++ b/cmac/hash.go
@@ -20,7 +20,6 @@ import (
 	"crypto/cipher"
 	"fmt"
 	"hash"
-	"log"
 	"unsafe"
 
 	"github.com/jacobsa/crypto/common"
@@ -104,28 +103,6 @@ func (h *cmacHash) writeBlocks(p []byte) {
 	}
 
 	return
-}
-
-// XOR the blockSize bytes starting at a and b, writing the result over dst.
-func xorBlock(
-	dstPtr unsafe.Pointer,
-	aPtr unsafe.Pointer,
-	bPtr unsafe.Pointer) {
-	// Check assumptions. (These are compile-time constants, so this should
-	// compile out.)
-	const wordSize = unsafe.Sizeof(uintptr(0))
-	if blockSize != 2*wordSize {
-		log.Panicf("%d %d", blockSize, wordSize)
-	}
-
-	// Convert.
-	a := (*[2]uintptr)(aPtr)
-	b := (*[2]uintptr)(bPtr)
-	dst := (*[2]uintptr)(dstPtr)
-
-	// Compute.
-	dst[0] = a[0] ^ b[0]
-	dst[1] = a[1] ^ b[1]
 }
 
 func (h *cmacHash) Sum(b []byte) []byte {

--- a/cmac/hash_386.go
+++ b/cmac/hash_386.go
@@ -1,0 +1,45 @@
+// Copyright 2012 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmac
+
+import (
+	"log"
+	"unsafe"
+)
+
+// XOR the blockSize bytes starting at a and b, writing the result over dst.
+func xorBlock(
+	dstPtr unsafe.Pointer,
+	aPtr unsafe.Pointer,
+	bPtr unsafe.Pointer) {
+	// Check assumptions. (These are compile-time constants, so this should
+	// compile out.)
+	const wordSize = unsafe.Sizeof(uintptr(0))
+	if blockSize != 4*wordSize {
+		log.Panicf("%d %d", blockSize, wordSize)
+	}
+
+	// Convert.
+	a := (*[4]uintptr)(aPtr)
+	b := (*[4]uintptr)(bPtr)
+	dst := (*[4]uintptr)(dstPtr)
+
+	// Compute.
+	dst[0] = a[0] ^ b[0]
+	dst[1] = a[1] ^ b[1]
+	dst[2] = a[2] ^ b[2]
+	dst[3] = a[3] ^ b[3]
+}

--- a/cmac/hash_amd64.go
+++ b/cmac/hash_amd64.go
@@ -1,0 +1,43 @@
+// Copyright 2012 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmac
+
+import (
+	"log"
+	"unsafe"
+)
+
+// XOR the blockSize bytes starting at a and b, writing the result over dst.
+func xorBlock(
+	dstPtr unsafe.Pointer,
+	aPtr unsafe.Pointer,
+	bPtr unsafe.Pointer) {
+	// Check assumptions. (These are compile-time constants, so this should
+	// compile out.)
+	const wordSize = unsafe.Sizeof(uintptr(0))
+	if blockSize != 2*wordSize {
+		log.Panicf("%d %d", blockSize, wordSize)
+	}
+
+	// Convert.
+	a := (*[2]uintptr)(aPtr)
+	b := (*[2]uintptr)(bPtr)
+	dst := (*[2]uintptr)(dstPtr)
+
+	// Compute.
+	dst[0] = a[0] ^ b[0]
+	dst[1] = a[1] ^ b[1]
+}


### PR DESCRIPTION
The xorBlock function expects the wordSize to be 8 bytes. On arch 386
this size is 4 bytes and xorBlock will panic. xorWords is copied from
golang's crypto/cipher/xor.go.