### PR TITLE
Add support for ARM achitecture (32 & 64 bits)

### DIFF
--- a/cmac/hash_32bit.go
+++ b/cmac/hash_32bit.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build 386 arm,!arm64
+
 package cmac
 
 import (
@@ -28,16 +30,18 @@ func xorBlock(
 	// Check assumptions. (These are compile-time constants, so this should
 	// compile out.)
 	const wordSize = unsafe.Sizeof(uintptr(0))
-	if blockSize != 2*wordSize {
+	if blockSize != 4*wordSize {
 		log.Panicf("%d %d", blockSize, wordSize)
 	}
 
 	// Convert.
-	a := (*[2]uintptr)(aPtr)
-	b := (*[2]uintptr)(bPtr)
-	dst := (*[2]uintptr)(dstPtr)
+	a := (*[4]uintptr)(aPtr)
+	b := (*[4]uintptr)(bPtr)
+	dst := (*[4]uintptr)(dstPtr)
 
 	// Compute.
 	dst[0] = a[0] ^ b[0]
 	dst[1] = a[1] ^ b[1]
+	dst[2] = a[2] ^ b[2]
+	dst[3] = a[3] ^ b[3]
 }

--- a/cmac/hash_64bit.go
+++ b/cmac/hash_64bit.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build amd64 arm64
+
 package cmac
 
 import (
@@ -28,18 +30,16 @@ func xorBlock(
 	// Check assumptions. (These are compile-time constants, so this should
 	// compile out.)
 	const wordSize = unsafe.Sizeof(uintptr(0))
-	if blockSize != 4*wordSize {
+	if blockSize != 2*wordSize {
 		log.Panicf("%d %d", blockSize, wordSize)
 	}
 
 	// Convert.
-	a := (*[4]uintptr)(aPtr)
-	b := (*[4]uintptr)(bPtr)
-	dst := (*[4]uintptr)(dstPtr)
+	a := (*[2]uintptr)(aPtr)
+	b := (*[2]uintptr)(bPtr)
+	dst := (*[2]uintptr)(dstPtr)
 
 	// Compute.
 	dst[0] = a[0] ^ b[0]
 	dst[1] = a[1] ^ b[1]
-	dst[2] = a[2] ^ b[2]
-	dst[3] = a[3] ^ b[3]
 }


### PR DESCRIPTION
I checked that it compiles fine for `386`, `amd64`, `arm` and `arm64` and the tests run fine for `386` and `amd64`. I only have a small `arm` box (32bits), so I didn't install GO on it, I just tried to run the tests precompiled. Most of them pass, but some failed due to missing package - `"github.com/jacobsa/crypto/testing/cases"`. I will try to run all the tests on a raspberry pi 2 soon.