### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/testing/cmac.go
+++ b/testing/cmac.go
@@ -35,7 +35,7 @@ func (c CmacTestCase) String() string {
 	return fmt.Sprintf("AES-CMAC(%x, %x) = %x", c.Key, c.Msg, c.Mac)
 }
 
-// CmacTestCases returns test cases for AES-CMAC.
+// CmacCases returns test cases for AES-CMAC.
 func CmacCases() []CmacTestCase {
 	// Find the source package.
 	pkg, err := build.Import(

--- a/testing/dbl.go
+++ b/testing/dbl.go
@@ -34,7 +34,7 @@ func (c DblTestCase) String() string {
 	return fmt.Sprintf("Dbl(%x) = %x", c.Input, c.Output)
 }
 
-// DblTestCases returns test cases for dbl.
+// DblCases returns test cases for dbl.
 func DblCases() []DblTestCase {
 	// Find the source package.
 	pkg, err := build.Import(

--- a/testing/encrypt.go
+++ b/testing/encrypt.go
@@ -41,7 +41,7 @@ func (c EncryptTestCase) String() string {
 		c.Output)
 }
 
-// EncryptTestCases returns test cases for Encrypt.
+// EncryptCases returns test cases for Encrypt.
 func EncryptCases() []EncryptTestCase {
 	// Find the source package.
 	pkg, err := build.Import(

--- a/testing/hex.go
+++ b/testing/hex.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 )
 
-// Decode a hex string that may contain spaces, as used in test vectors in
+// FromRfcHex decodes a hex string that may contain spaces, as used in test vectors in
 // RFCs. Panic if the input is illegal.
 func FromRfcHex(s string) []byte {
 	// Remove spaces.

--- a/testing/s2v.go
+++ b/testing/s2v.go
@@ -35,7 +35,7 @@ func (c S2vTestCase) String() string {
 	return fmt.Sprintf("S2v(%x, %x) = %x", c.Key, c.Strings, c.Output)
 }
 
-// S2vTestCases returns test cases for S2V.
+// S2vCases returns test cases for S2V.
 func S2vCases() []S2vTestCase {
 	// Find the source package.
 	pkg, err := build.Import(


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?