### PR TITLE
Add generic implementation of xorBlock

### DIFF
--- a/cmac/hash_generic.go
+++ b/cmac/hash_generic.go
@@ -1,0 +1,40 @@
+// Copyright 2012 Aaron Jacobs. All Rights Reserved.
+// Author: aaronjjacobs@gmail.com (Aaron Jacobs)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build riscv64
+
+// This code doesn't require that it's safe to perform unaligned word-sized loads, but has a poor performance.
+
+package cmac
+
+import (
+	"unsafe"
+)
+
+// XOR the blockSize bytes starting at a and b, writing the result over dst.
+func xorBlock(
+	dstPtr unsafe.Pointer,
+	aPtr unsafe.Pointer,
+	bPtr unsafe.Pointer) {
+	// Convert.
+	a := (*[blockSize]byte)(aPtr)
+	b := (*[blockSize]byte)(bPtr)
+	dst := (*[blockSize]byte)(dstPtr)
+
+	// Compute.
+	for i := 0; i < blockSize; i++ {
+		dst[i] = a[i] ^ b[i]
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/jacobsa/crypto
+
+go 1.16
+
+require (
+	github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd
+	github.com/jacobsa/oglemock v0.0.0-20150831005832-e94d794d06ff // indirect
+	github.com/jacobsa/ogletest v0.0.0-20170503003838-80d50a735a11
+	github.com/jacobsa/reqtrace v0.0.0-20150505043853-245c9e0234cb // indirect
+	golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd h1:9GCSedGjMcLZCrusBZuo4tyKLpKUPenUUqi34AkuFmA=
+github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd/go.mod h1:TlmyIZDpGmwRoTWiakdr+HA1Tukze6C6XbRVidYq02M=
+github.com/jacobsa/oglemock v0.0.0-20150831005832-e94d794d06ff h1:2xRHTvkpJ5zJmglXLRqHiZQNjUoOkhUyhTAhEQvPAWw=
+github.com/jacobsa/oglemock v0.0.0-20150831005832-e94d794d06ff/go.mod h1:gJWba/XXGl0UoOmBQKRWCJdHrr3nE0T65t6ioaj3mLI=
+github.com/jacobsa/ogletest v0.0.0-20170503003838-80d50a735a11 h1:BMb8s3ENQLt5ulwVIHVDWFHp8eIXmbfSExkvdn9qMXI=
+github.com/jacobsa/ogletest v0.0.0-20170503003838-80d50a735a11/go.mod h1:+DBdDyfoO2McrOyDemRBq0q9CMEByef7sYl7JH5Q3BI=
+github.com/jacobsa/reqtrace v0.0.0-20150505043853-245c9e0234cb h1:uSWBjJdMf47kQlXMwWEfmc864bA1wAC+Kl3ApryuG9Y=
+github.com/jacobsa/reqtrace v0.0.0-20150505043853-245c9e0234cb/go.mod h1:ivcmUvxXWjb27NsPEaiYK7AidlZXS7oQ5PowUS9z3I4=
+golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d h1:LO7XpTYMwTqxjLcGWPijK3vRXg1aWdlNOVOHRq45d7c=
+golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/testing/cases/cases.go
+++ b/testing/cases/cases.go
@@ -1,0 +1,1 @@
+package cases


### PR DESCRIPTION
This PR is based on #12 and will fix #13.

The generic implementation doesn't require that it's safe to perform unaligned word-sized loads, but has a poor performance.

Also, I wonder whether the related code can be rewritten to not use unaligned memory accesses?